### PR TITLE
Potential fix for code scanning alert no. 52: Overly permissive regular expression range

### DIFF
--- a/scripts/preview-theme.js
+++ b/scripts/preview-theme.js
@@ -339,7 +339,7 @@ const parseJSON = (json) => {
     let parsedJson = json.replace(/(,\s*})/g, "}");
 
     // Remove JS comments (if any).
-    parsedJson = parsedJson.replace(/\/\/[A-z\s]*\s/g, "");
+    parsedJson = parsedJson.replace(/\/\/[A-Za-z\s]*\s/g, "");
 
     // Fix incorrect open bracket (if any).
     const splitJson = parsedJson


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/52](https://github.com/dytsou/github-readme-stats/security/code-scanning/52)

To fix the problem, the regular expression should be corrected to only include the intended range of characters. If the goal is to match English letters, use `[A-Za-z]` instead of `[A-z]`. It's also a best practice to be explicit about which characters you want to allow in the pattern. Therefore, the regular expression on line 342 should be changed from `/\/\/[A-z\s]*\s/g` to `/\/\/[A-Za-z\s]*\s/g`. This change ensures only uppercase and lowercase English letters (A-Z, a-z) and whitespace characters are matched as part of the comment, faithfully reflecting standard JavaScript usage and preventing accidental matches of unintended punctuation.

The only required change is in the regular expression pattern within `parsedJson.replace(...)` on line 342 of `scripts/preview-theme.js`. No additional imports, methods, or supporting code are required, as no functionality besides the regular expression match needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
