### PR TITLE
Potential fix for code scanning alert no. 53: Unsafe HTML constructed from library input

### DIFF
--- a/src/common/render.js
+++ b/src/common/render.js
@@ -41,7 +41,7 @@ const createLanguageNode = (langName, langColor) => {
   return `
     <g data-testid="primary-lang">
       <circle data-testid="lang-color" cx="0" cy="-5" r="6" fill="${langColor}" />
-      <text data-testid="lang-name" class="gray" x="15">${langName}</text>
+      <text data-testid="lang-name" class="gray" x="15">${encodeHTML(langName)}</text>
     </g>
     `;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/53](https://github.com/dytsou/github-readme-stats/security/code-scanning/53)

The best way to fix the problem is to ensure all user-controllable content interpolated into HTML or SVG markup is safely escaped. This can be accomplished by passing all such values through a sanitization function like `encodeHTML` before interpolating into the string templates. In this case, `createLanguageNode` needs to escape its `langName` parameter before inserting it into the `<text>` tag. That's the principal location where untrusted flow enters without escaping. This also covers the tainted flow through `flexLayout`, since it only wraps items passed to it, and the real risk comes from unsanitized values reaching template interpolations.

Changes required:
- In `src/common/render.js`, update the implementation of `createLanguageNode` so that `langName` is passed through `encodeHTML` before interpolation into the string template.
- No import changes required, since `encodeHTML` is already imported in `render.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
