### PR TITLE
Potential fix for code scanning alert no. 82: Reflected cross-site scripting

### DIFF
--- a/src/common/I18n.js
+++ b/src/common/I18n.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { encodeHTML } from "./html.js";
 const FALLBACK_LOCALE = "en";
 
 /**
@@ -31,7 +32,7 @@ class I18n {
 
     if (!this.translations[str][this.locale]) {
       throw new Error(
-        `'${str}' translation not found for locale '${this.locale}'`,
+        `'${str}' translation not found for locale '${encodeHTML(this.locale)}'`,
       );
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/82](https://github.com/dytsou/github-readme-stats/security/code-scanning/82)

To resolve this issue, we should ensure that any dynamic data originating from user input that is included in error messages is properly sanitized/encoded before being rendered in HTML/SVG responses, even if some validation is present. In this case, where error messages in src/common/I18n.js use `this.locale` in thrown errors, and these error strings are eventually surfaced to the user, it is wise to sanitize/escape the `locale` variable when embedding it in error messages.

Specifically, in src/common/I18n.js, in the constructor and the `t()` method, wherever error messages are constructed that interpolate `this.locale`, we should ensure the locale value is encoded via the same `encodeHTML()` function used in rendering. To do this:
- Import `encodeHTML` from src/common/html.js within src/common/I18n.js.
- Use `encodeHTML(this.locale)` in error message construction (line 34) and anywhere else locale is interpolated into response/output.
- Confirm that all other dynamic strings provided by the user and shown to the client are also properly encoded.

These edits should be made in src/common/I18n.js, particularly in the `t()` method where translation errors are thrown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
