### PR TITLE
Potential fix for code scanning alert no. 76: Reflected cross-site scripting

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -109,10 +109,19 @@ export default async (req, res) => {
   } catch (err) {
     setErrorCacheHeaders(res);
     if (err instanceof Error) {
+      // Prevent leaking user locale in error message
+      let safeMessage = err.message;
+      // Generic error handling for translation not found errors
+      if (
+        safeMessage &&
+        safeMessage.includes("translation not found for locale")
+      ) {
+        safeMessage = "Invalid locale specified.";
+      }
       // Validate colors before passing to renderError (renderError will also sanitize)
       return res.send(
         renderError({
-          message: err.message,
+          message: safeMessage,
           secondaryMessage: retrieveSecondaryMessage(err),
           renderOptions: {
             title_color: validateColor(title_color),


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/76](https://github.com/dytsou/github-readme-stats/security/code-scanning/76)

The best fix is to ensure that error messages sent to `renderError`, especially those resulting from failed translation lookups due to invalid or malicious locales, do not contain unsanitized user-controlled input. When an error is caught after a failed translation lookup (which throws an error containing the locale string), rather than directly using `err.message`, we should instead display a generic error ("Invalid locale specified" or similar), or use a fallback locale value (which is trusted), thus avoiding reflecting the user-provided locale in the output at all. 

Specifically, in `api/wakatime.js`, in the error handling block of the Wakatime card endpoint (lines 109–126), before calling `renderError`, if the error is a result of a translation lookup, swap out the error message for a generic one. This can be checked by confirming the error is an instance of Error and the message matches the known "translation not found" format (or the error came from I18n.js). Optionally, handle all errors from I18n translation lookups with a generic user-facing message. No change is needed elsewhere: the rest of the error rendering pipeline already encodes output.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
