### PR TITLE
Potential fix for code scanning alert no. 98: Reflected cross-site scripting

### DIFF
--- a/src/common/I18n.js
+++ b/src/common/I18n.js
@@ -32,7 +32,7 @@ class I18n {
 
     if (!this.translations[str][this.locale]) {
       throw new Error(
-        `'${str}' translation not found for locale '${encodeHTML(this.locale)}'`,
+        `'${str}' translation not found for locale.`,
       );
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/98](https://github.com/dytsou/github-readme-stats/security/code-scanning/98)

To fix the problem, we need to guarantee that user-controlled values, such as `locale`, are never reflected in error messages, even in encoded form. Specifically, any occurrence of user input in error strings (e.g., locale information in missing-translation errors) should be either omitted or replaced by generic, static text.

The best way to do so is:
- Change the error thrown in `I18n.t()` when a translation for a missing locale is encountered. Instead of
  ```
  throw new Error(
    `'${str}' translation not found for locale '${encodeHTML(this.locale)}'`,
  );
  ```
  simply throw:
  ```
  throw new Error(`'${str}' translation not found for locale.`);
  ```
  or use a message that completely avoids including the user-supplied locale string.
- This ensures that even if the handler misses replacing the error message text, no attacker-controlled string is ever reflected.

We only need to edit `src/common/I18n.js` in the line that throws the error for missing locales. This retains current functionality while eliminating the XSS vector.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
