### PR TITLE
Potential fix for code scanning alert no. 53: Unsafe HTML constructed from library input

### DIFF
--- a/src/common/render.js
+++ b/src/common/render.js
@@ -38,9 +38,10 @@ const flexLayout = ({ items, gap, direction, sizes = [] }) => {
  * @returns {string} Language display SVG object.
  */
 const createLanguageNode = (langName, langColor) => {
+  const safeLangColor = escapeCSSValue(langColor);
   return `
     <g data-testid="primary-lang">
-      <circle data-testid="lang-color" cx="0" cy="-5" r="6" fill="${langColor}" />
+      <circle data-testid="lang-color" cx="0" cy="-5" r="6" fill="${safeLangColor}" />
       <text data-testid="lang-name" class="gray" x="15">${encodeHTML(langName)}</text>
     </g>
     `;


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/53](https://github.com/dytsou/github-readme-stats/security/code-scanning/53)

To fix the issue, we need to ensure `langColor` is safely escaped/validated before being interpolated as an SVG attribute. Because SVG color attributes expect valid CSS color strings, we should use escaping to ensure non-malicious input, or a strict validation step (e.g., regex or a whitelist). Fortunately, the code already has an `escapeCSSValue` function for sanitizing CSS values. We should apply `escapeCSSValue` to `langColor` as soon as it is received or before it is rendered, just as is done elsewhere for color attributes. We must update the invocation of `createLanguageNode`, its signature, and its usage sites so that the argument is escaped, or alternatively, we can escape it inside `createLanguageNode` itself to ensure it's always safe. This addresses all occurrences of potentially unsafe color input before it is rendered to SVG.

**Required changes:**
- Update `createLanguageNode` (in src/common/render.js) to escape `langColor` via `escapeCSSValue`.
- Update usage sites/callers in src/cards/repo.js so that the color value is passed as is.
- No external dependencies required, as all required escaping functions are present already.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
