### PR TITLE
Potential fix for code scanning alert no. 100: Reflected cross-site scripting

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -17,7 +17,7 @@ import {
 } from "../src/common/error.js";
 import { parseArray, parseBoolean } from "../src/common/ops.js";
 import { validateColor, validateTheme } from "../src/common/color.js";
-import { encodeHTML } from "../src/common/html.js";
+import { encodeHTML, sanitizeTitle } from "../src/common/html.js";
 
 // @ts-ignore
 export default async (req, res) => {
@@ -92,9 +92,11 @@ export default async (req, res) => {
     const safeTheme = validateTheme(theme);
     const safeBorderColor = validateColor(border_color);
 
-    // Sanitize custom title for SVG/text usage
+    // Sanitize custom title for SVG/text usage (restrict and encode)
     const safeCustomTitle =
-      typeof custom_title === "string" ? encodeHTML(custom_title) : undefined;
+      typeof custom_title === "string"
+        ? encodeHTML(sanitizeTitle(custom_title))
+        : undefined;
 
     // Validate border_radius (float [0, 20] as reasonable range)
     let safeBorderRadius = parseFloat(border_radius);

--- a/src/common/html.js
+++ b/src/common/html.js
@@ -17,6 +17,21 @@ const encodeHTML = (str) => {
 };
 
 /**
+ * Restricts title strings to a safe printable unicode subset.
+ * Only allows unicode letters, numbers, punctuation, space, emoji.
+ * Strips any characters that may risk SVG/HTML XSS escape.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+const sanitizeTitle = (str) => {
+  if (typeof str !== "string") return "";
+  // Remove all control chars except whitespace, allow common printable chars plus unicode
+  // Unicode letters/numbers/punctuation/marks/symbols/spaces (\p{L}\p{N}\p{P}\p{M}\p{S}\p{Zs})
+  return str.replace(/[^\p{L}\p{N}\p{P}\p{M}\p{S}\p{Zs}]/gu, "");
+};
+
+/**
  * Escape CSS/attribute value to prevent XSS in SVG attributes.
  * This function ensures that color values and other CSS values
  * are safe to use in SVG attribute contexts.
@@ -41,4 +56,4 @@ const escapeCSSValue = (value) => {
     .replace(/>/g, "\\3E "); // Escape greater-than
 };
 
-export { encodeHTML, escapeCSSValue };
+export { encodeHTML, escapeCSSValue, sanitizeTitle };


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/100](https://github.com/dytsou/github-readme-stats/security/code-scanning/100)

**General fix:**  
Restrict `custom_title` either to a very strict subset of printable characters (whitelist/allowlist), or use a robust SVG/HTML sanitizer such as `escape-html` or a dedicated SVG-safe string encoding, **in addition to** the current HTML encoding. Since SVG contexts are stricter than HTML, and manual regex-based encoding is error prone, we should both defend in depth and reinforce the sanitization logic.

**Detailed fix:**  
- In `api/wakatime.js`, after the `encodeHTML(custom_title)` (the current safeCustomTitle logic), add a second layer of runtime input restriction: only accept `custom_title` values that match a conservative allowlist of “safe” printable, non-control characters (e.g., `/^[\p{L}\p{N}\p{P}\p{Zs}]*$/u` for unicode letters/numbers/punctuation/spaces).
- Alternatively, but preferable for clarity and ease of maintenance, introduce a helper function in `src/common/html.js` like `sanitizeTitle` that strips or rejects (e.g., replaces with an empty string) any dangerous characters, and use that in `api/wakatime.js`.
- Update the `safeCustomTitle` definition to pass the (user) input through both `encodeHTML` and the new `sanitizeTitle`. This ensures a defense-in-depth approach.
- Optionally, update docstrings to explain the defense.
- No changes needed for deep library dependencies: rely on built-in or already-present infrastructure.

**Where to change:**  
- Add `sanitizeTitle` in `src/common/html.js`.
- Use this in `api/wakatime.js` (line 96–97 region).
- Be sure to use the new sanitizer before encodeHTML, or combine as needed so that user input is both restricted and encoded.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
