### PR TITLE
Potential fix for code scanning alert no. 53: Unsafe HTML constructed from library input

### DIFF
--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -202,6 +202,15 @@ class Card {
   };
 
   /**
+   * Renders the card with inner body HTML/SVG.
+   *
+   * ⚠️ SECURITY WARNING:
+   * The `body` parameter is injected as raw HTML/SVG into the card.
+   * To avoid cross-site scripting (XSS) vulnerabilities, YOU MUST ensure
+   * that all content passed via `body` is trusted and properly sanitized.
+   * If your content contains user input, sanitize with `encodeHTML` or equivalent,
+   * and DO NOT pass unsanitized user input.
+   *
    * @param {string} body The inner body of the card.
    * @returns {string} The rendered card.
    */


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/53](https://github.com/dytsou/github-readme-stats/security/code-scanning/53)

To thoroughly address the problem, we should:
1. **Document the risk** on the `Card.render()` method, warning users that only sanitized or trusted input should be passed to the `body` parameter, or alternatively that user-generated content must be escaped (preferably with `encodeHTML`) before rendering.
2. **Defensively sanitize** within `Card.render()`, if feasible: If card clients consistently pass fragmented or already sanitized SVG, a blanket re-escaping is non-trivial and may break valid SVG. Therefore, the best practice is documentation, but optionally, we could wrap the interface to only accept items generated from known safe rendering helpers, or apply a sanitizer to fragments passed as `body`.
3. **Document/annotate** in code and JSDoc comments, as well as in the exports for `Card` so downstream consumers are warned.
4. Add one or more JSDoc comments above `Card.render()` (and optionally, the export), following best practices.

Only `src/common/Card.js` requires modification for documentation, as the code for input escaping elsewhere already applies `encodeHTML` appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
