### PR TITLE
Remove HTML encoding from API responses

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -14,7 +14,6 @@ import {
   resolveCacheSeconds,
   setCacheHeaders,
 } from "../src/common/cache.js";
-import { encodeHTML } from "../src/common/html.js";
 import { parseArray, parseBoolean } from "../src/common/ops.js";
 import { fetchTopLanguages } from "../src/fetchers/top-languages.js";
 import { isLocaleAvailable } from "../src/translations.js";
@@ -135,7 +134,7 @@ export default async (req, res) => {
 
     return res.send(
       renderTopLanguages(topLangs, {
-        custom_title: custom_title ? encodeHTML(custom_title) : undefined,
+        custom_title,
         hide_title: parseBoolean(hide_title),
         hide_border: parseBoolean(hide_border),
         card_width: parseInt(card_width, 10),

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -14,7 +14,6 @@ import {
   setCacheHeaders,
 } from "../src/common/cache.js";
 import { validateColor } from "../src/common/color.js";
-import { encodeHTML } from "../src/common/html.js";
 import { parseArray, parseBoolean } from "../src/common/ops.js";
 import { fetchWakatimeStats } from "../src/fetchers/wakatime.js";
 import { isLocaleAvailable } from "../src/translations.js";
@@ -90,13 +89,10 @@ export default async (req, res) => {
 
     setCacheHeaders(res, cacheSeconds);
 
-    // Sanitize custom title for SVG/text usage
-    const safeCustomTitle =
-      typeof custom_title === "string" ? encodeHTML(custom_title) : undefined;
-
     return res.send(
       renderWakatimeCard(stats, {
-        custom_title: safeCustomTitle,
+        // Card.js handles HTML encoding of custom_title internally
+        custom_title,
         hide_title: parseBoolean(hide_title),
         hide_border: parseBoolean(hide_border),
         card_width: parseInt(card_width, 10),

--- a/src/common/html.js
+++ b/src/common/html.js
@@ -21,16 +21,15 @@ const encodeHTML = (str) => {
  * This function ensures that color values and other CSS values
  * are safe to use in SVG attribute contexts.
  *
- * @param {string} value The CSS/attribute value to escape.
+ * @param {string|string[]} value The CSS/attribute value to escape.
  * @returns {string} Escaped value safe for use in SVG attributes.
  */
 const escapeCSSValue = (value) => {
-  if (typeof value !== "string") {
-    return String(value);
-  }
+  // Convert non-string values (e.g., arrays for gradients) to string first
+  const strValue = typeof value === "string" ? value : String(value);
 
   // Escape quotes and special characters that could break out of attribute context
-  return value
+  return strValue
     .replace(/\\/g, "\\\\") // Escape backslashes first
     .replace(/"/g, '\\"') // Escape double quotes
     .replace(/'/g, "\\'") // Escape single quotes


### PR DESCRIPTION
- Eliminated the `encodeHTML` import from `top-langs.js` and `wakatime.js`, simplifying the handling of `custom_title` by allowing the rendering components to manage HTML encoding internally.
- Updated related logic to ensure consistent handling of custom titles across API endpoints.