### PR TITLE
Sanitize rankLevel in rankIcon to prevent XSS

### DIFF
--- a/src/common/icons.js
+++ b/src/common/icons.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import escapeHtml from "escape-html";
+
 const icons = {
   star: `<path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"/>`,
   commits: `<path fill-rule="evenodd" d="M1.643 3.143L.427 1.927A.25.25 0 000 2.104V5.75c0 .138.112.25.25.25h3.646a.25.25 0 00.177-.427L2.715 4.215a6.5 6.5 0 11-1.18 4.458.75.75 0 10-1.493.154 8.001 8.001 0 101.6-5.684zM7.75 4a.75.75 0 01.75.75v2.992l2.028.812a.75.75 0 01-.557 1.392l-2.5-1A.75.75 0 017 8.25v-3.5A.75.75 0 017.75 4z"/>`,
@@ -19,8 +21,12 @@ const icons = {
 /**
  * Get rank icon
  *
+ * **Security Note:** This function safely handles untrusted input by HTML-encoding
+ * the `rankLevel` parameter. Data from external APIs (like GitHub) is sanitized
+ * before being inserted into the SVG.
+ *
  * @param {string} rankIcon - The rank icon type.
- * @param {string} rankLevel - The rank level.
+ * @param {string} rankLevel - The rank level (will be HTML-encoded).
  * @param {number} percentile - The rank percentile.
  * @returns {string} - The SVG code of the rank icon
  */
@@ -33,6 +39,7 @@ const rankIcon = (rankIcon, rankLevel, percentile) => {
         </svg>
       `;
     case "percentile":
+      // percentile.toFixed(1) produces numeric strings (e.g., "99.5"), safe to use directly
       return `
         <text x="-5" y="-12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-top-header" class="rank-percentile-header">
           Top
@@ -43,9 +50,10 @@ const rankIcon = (rankIcon, rankLevel, percentile) => {
       `;
     case "default":
     default:
+      // Sanitize rankLevel from external API to prevent XSS
       return `
         <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="level-rank-icon">
-          ${rankLevel}
+          ${escapeHtml(rankLevel || "")}
         </text>
       `;
   }


### PR DESCRIPTION
Sanitize the rankLevel parameter from GitHub API using escapeHtml() before interpolating it into SVG. This prevents XSS vulnerabilities when rank level data from external APIs is rendered.

Changes:
- Import escapeHtml from escape-html package
- Sanitize rankLevel in the default case of rankIcon function
- Add security documentation to rankIcon JSDoc