### PR TITLE
Add permissions for contents in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to npm and GitHub Packages


### PR DESCRIPTION
Introduce permissions for contents in the publish workflow to enhance clarity and ensure proper access for publishing to npm and GitHub Packages. This aligns with recent updates in other workflow files.