### PR TITLE
Potential fix for code scanning alert no. 63: Reflected cross-site scripting

### DIFF
--- a/api/gist.js
+++ b/api/gist.js
@@ -78,15 +78,14 @@ export default async (req, res) => {
         text_color,
         bg_color,
         theme,
-        border_radius:
-          (() => {
-            // Validate border_radius: must be a finite number between 0 and 50
-            const num = parseFloat(border_radius);
-            if (isNaN(num) || !isFinite(num) || num < 0 || num > 50) {
-              return undefined; // Let card use its default
-            }
-            return num;
-          })(),
+        border_radius: (() => {
+          // Validate border_radius: must be a finite number between 0 and 50
+          const num = parseFloat(border_radius);
+          if (isNaN(num) || !isFinite(num) || num < 0 || num > 50) {
+            return undefined; // Let card use its default
+          }
+          return num;
+        })(),
         border_color,
         locale,
         show_owner: parseBoolean(show_owner),


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/63](https://github.com/dytsou/github-readme-stats/security/code-scanning/63)

To fix the issue, ensure that the `border_radius` value supplied by the user cannot be used to inject arbitrary content into the SVG output. The best way to do this is:

- **Validate and sanitize `border_radius`** before passing it to the render function or using it in an SVG attribute.  
- Accept only numeric values, and default to a safe value if the input is missing or invalid.
- You can do this by parsing the value using `parseFloat` or `Number`, checking it for finiteness and restrict its range to reasonable limits (e.g., between `0` and `50`).
- Implement this validation within the API endpoint (`api/gist.js`) so that only sanitized values enter card rendering logic.
- Alternatively (or additionally), perform validation in `src/cards/gist.js` if the value might be reused elsewhere.

**Required changes:**
- In `api/gist.js`: Before rendering, validate and sanitize the incoming border_radius value, and only pass the sanitized value to `renderGistCard`.
- No new imports are needed for basic numeric validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
