### PR TITLE
Potential fix for code scanning alert no. 64: Reflected cross-site scripting

### DIFF
--- a/api/pin.js
+++ b/api/pin.js
@@ -37,9 +37,11 @@ export default async (req, res) => {
 
   // Only allow supported locales - validate and sanitize to prevent XSS
   // Validate and sanitize border_radius to prevent XSS
-  const border_radius = (()=>{
+  const border_radius = (() => {
     const br = parseFloat(rawBorderRadius);
-    if (isNaN(br)) return 4.5;
+    if (isNaN(br)) {
+      return 4.5;
+    }
     // Clamp to reasonable range; SVG border radius shouldn't exceed half width/height.
     return Math.max(0, Math.min(br, 50));
   })();


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/64](https://github.com/dytsou/github-readme-stats/security/code-scanning/64)

To fix the XSS vulnerability, we must ensure that `border_radius` is sanitized before being used in any SVG output. The best approach is to:
- Parse the `border_radius` value as a number, clamp it to a reasonable safe range (e.g., between 0 and 50), and fallback to the default value (`4.5`) if the parsing fails.
- This input validation should occur as soon as possible after extracting the user input (in `api/pin.js`), so that all downstream consumers receive only safe data.
- If desired, additional validation can be performed in `src/cards/repo.js` and/or `src/common/Card.js` constructor, but the main fix is to ensure that only a properly parsed/clamped number is ever passed down.
- Use a helper (such as `clampValue` from `src/common/ops.js`, which is already imported in `src/cards/repo.js`) or simply implement a clamp utility directly if not available.

The only file that requires changes is `api/pin.js`; add a block to validate/sanitize `border_radius` immediately after extracting it from `req.query`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
