### PR TITLE
Potential fix for code scanning alert no. 70: Reflected cross-site scripting

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -98,45 +98,48 @@ export default async (req, res) => {
 
     setCacheHeaders(res, cacheSeconds);
 
-    // Sanitize border_radius: parse, clamp, fallback to undefined if invalid
-    const sanitizedBorderRadius = clampValue(
-      Number(border_radius),
-      0,
-      50
-    );
-    return res.send(
-      renderStatsCard(stats, {
-        hide: parseArray(hide),
-        show_icons: parseBoolean(show_icons),
-        hide_title: parseBoolean(hide_title),
-        hide_border: parseBoolean(hide_border),
-        card_width: parseInt(card_width, 10),
-        hide_rank: parseBoolean(hide_rank),
-        include_all_commits: parseBoolean(include_all_commits),
-        commits_year: parseInt(commits_year, 10),
-        line_height,
-        title_color,
-        ring_color,
-        icon_color,
-        text_color,
-        text_bold: parseBoolean(text_bold),
-        bg_color,
-        theme,
-        // Validate custom_title is a string (prevents array from duplicate query params)
-        // Card.js handles HTML encoding internally
-        custom_title:
-          typeof custom_title === "string" ? custom_title : undefined,
-        border_radius:
-          Number.isFinite(sanitizedBorderRadius) ? sanitizedBorderRadius : undefined,
-        border_color,
-        number_format,
-        number_precision: parseInt(number_precision, 10),
-        locale,
-        disable_animations: parseBoolean(disable_animations),
-        rank_icon,
-        show: showStats,
-      }),
-    );
+    // Sanitize border_radius: parse, clamp, only include if valid
+    const borderRadiusNum = Number(border_radius);
+    const sanitizedBorderRadius =
+      Number.isFinite(borderRadiusNum) && border_radius !== undefined
+        ? clampValue(borderRadiusNum, 0, 50)
+        : undefined;
+
+    const renderOptions = {
+      hide: parseArray(hide),
+      show_icons: parseBoolean(show_icons),
+      hide_title: parseBoolean(hide_title),
+      hide_border: parseBoolean(hide_border),
+      card_width: parseInt(card_width, 10),
+      hide_rank: parseBoolean(hide_rank),
+      include_all_commits: parseBoolean(include_all_commits),
+      commits_year: parseInt(commits_year, 10),
+      line_height,
+      title_color,
+      ring_color,
+      icon_color,
+      text_color,
+      text_bold: parseBoolean(text_bold),
+      bg_color,
+      theme,
+      // Validate custom_title is a string (prevents array from duplicate query params)
+      // Card.js handles HTML encoding internally
+      custom_title: typeof custom_title === "string" ? custom_title : undefined,
+      border_color,
+      number_format,
+      number_precision: parseInt(number_precision, 10),
+      locale,
+      disable_animations: parseBoolean(disable_animations),
+      rank_icon,
+      show: showStats,
+    };
+
+    // Only include border_radius if it's valid, otherwise let Card use default
+    if (sanitizedBorderRadius !== undefined) {
+      renderOptions.border_radius = sanitizedBorderRadius;
+    }
+
+    return res.send(renderStatsCard(stats, renderOptions));
   } catch (err) {
     return handleApiError({ res, error: err, colorOptions });
   }

--- a/api/pin.js
+++ b/api/pin.js
@@ -12,7 +12,7 @@ import {
   resolveCacheSeconds,
   setCacheHeaders,
 } from "../src/common/cache.js";
-import { parseBoolean } from "../src/common/ops.js";
+import { clampValue, parseBoolean } from "../src/common/ops.js";
 import { fetchRepo } from "../src/fetchers/repo.js";
 import { isLocaleAvailable } from "../src/translations.js";
 
@@ -73,21 +73,32 @@ export default async (req, res) => {
 
     setCacheHeaders(res, cacheSeconds);
 
-    return res.send(
-      renderRepoCard(repoData, {
-        hide_border: parseBoolean(hide_border),
-        title_color,
-        icon_color,
-        text_color,
-        bg_color,
-        theme,
-        border_radius,
-        border_color,
-        show_owner: parseBoolean(show_owner),
-        locale,
-        description_lines_count,
-      }),
-    );
+    // Sanitize border_radius: parse, clamp, only include if valid
+    const borderRadiusNum = Number(border_radius);
+    const sanitizedBorderRadius =
+      Number.isFinite(borderRadiusNum) && border_radius !== undefined
+        ? clampValue(borderRadiusNum, 0, 50)
+        : undefined;
+
+    const renderOptions = {
+      hide_border: parseBoolean(hide_border),
+      title_color,
+      icon_color,
+      text_color,
+      bg_color,
+      theme,
+      border_color,
+      show_owner: parseBoolean(show_owner),
+      locale,
+      description_lines_count,
+    };
+
+    // Only include border_radius if it's valid, otherwise let Card use default
+    if (sanitizedBorderRadius !== undefined) {
+      renderOptions.border_radius = sanitizedBorderRadius;
+    }
+
+    return res.send(renderRepoCard(repoData, renderOptions));
   } catch (err) {
     return handleApiError({ res, error: err, colorOptions });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/github-readme-stats/security/code-scanning/70](https://github.com/dytsou/github-readme-stats/security/code-scanning/70)

To fix the reflected cross-site scripting vulnerability, we need to ensure that `border_radius`, which is exposed to user input via query parameters, is strictly validated and sanitized before being used in the SVG output. The safest approach is to coerce it to a numeric value and clamp it to a reasonable range (e.g., 0 to 50). This prevents any possibility of injecting malicious code via malformed string input.

Specifically, in `api/index.js`, before passing `border_radius` to `renderStatsCard`, we should:
- Parse `border_radius` as a float (since it may not be an integer).
- Clamp it within reasonable bounds.
- If it fails to parse (is `NaN`), we should default to the intended value (e.g., `4.5`), or leave it `undefined` so the Card class falls back to its default.

Necessary changes:
- In `api/index.js`, add a helper function `clampValue` for boundary checks (if not already present via imports).
- When constructing the options for `renderStatsCard`, replace `border_radius` with the sanitized/clamped value.

No changes are needed in `src/common/Card.js` or `src/cards/stats.js` unless `clampValue` or equivalent is not available. If it already exists (as seen by `clampValue` imported in `src/cards/stats.js`), use/import it in `api/index.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
